### PR TITLE
exclude manifest signature files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,16 @@
                   <mainClass>com.cloudant.search3.Main</mainClass>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When running java -jar, we get a security error for signature
mistmatches. This excludes them in order to build an uberjar
with mvn shade.

https://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar/6743609#6743609