### PR TITLE
Close all resources safely

### DIFF
--- a/src/main/java/com/cloudant/search3/FDBDirectorySearchHandler.java
+++ b/src/main/java/com/cloudant/search3/FDBDirectorySearchHandler.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.grouping.GroupDocs;
 import org.apache.lucene.search.grouping.GroupingSearch;
 import org.apache.lucene.search.grouping.TopGroups;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
 
 import com.cloudant.fdblucene.FDBDirectory;
 import com.cloudant.search3.grpc.Search3.DocumentDeleteRequest;
@@ -78,8 +79,7 @@ public final class FDBDirectorySearchHandler extends BaseSearchHandler {
 
     @Override
     public void close() throws IOException {
-        this.manager.close();
-        this.writer.rollback();
+        IOUtils.close(this.manager, this.writer, this.dir);
     }
 
     @Override

--- a/src/main/java/com/cloudant/search3/FDBDirectorySearchHandlerFactory.java
+++ b/src/main/java/com/cloudant/search3/FDBDirectorySearchHandlerFactory.java
@@ -74,6 +74,7 @@ public final class FDBDirectorySearchHandlerFactory implements SearchHandlerFact
     private static IndexWriterConfig indexWriterConfig(final Analyzer analyzer) {
         final IndexWriterConfig result = new IndexWriterConfig(analyzer);
         result.setUseCompoundFile(false);
+        result.setCommitOnClose(false);
         return result;
     }
 


### PR DESCRIPTION
* Close the FDBDirectory explicitly, freeing the page cache sooner.
* Close all resources, even if one throws an IOException.
* Explicitly configure IndexWriter.close() to rollback.