### PR TITLE
tweaks/comments on test TLS asset building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ all: ca.pem
 
 ca.pem:
 	@certstrap init --common-name somewhere.over.the.rainbow --passphrase ""
-	@certstrap request-cert -ip 127.0.0.1 --passphrase ""
-	@certstrap sign 127.0.0.1 --CA somewhere.over.the.rainbow --passphrase ""
-	@openssl pkcs8 -topk8 -nocrypt -in out/127.0.0.1.key -out key.pem
-	@cp out/127.0.0.1.crt cert.pem
+	@certstrap request-cert -ip 127.0.0.1 --passphrase "" -domain localhost
+	@certstrap sign localhost --CA somewhere.over.the.rainbow --passphrase ""
+	@openssl pkcs8 -topk8 -nocrypt -in out/localhost.key -out key.pem
+	@cp out/localhost.crt cert.pem
 	@cp out/somewhere.over.the.rainbow.crt ca.pem
 
 clean:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ alone.
 check messages.
 
 * `src/proto/search3.proto` - defines the grpc protocol required for
-text indexing and text searching. 
+text indexing and text searching.
 
 Build
 -----
@@ -86,3 +86,5 @@ tls.cert_file = <path to>/cert.pem
 tls.key_file = <path to>/key.pem
 tls.ca_file = <path to>/ca.pem
 tls.enabled = true
+
+A make rule, `make ca.pem`, is available to easily build the cert, key, and ca for test purposes.


### PR DESCRIPTION
I had to make these changes or else the `certstrap request-cert` step would complain about the lack of a domain or common-name. If I specified the common-name again it would fail and complain about the `somewhere.over.the.rainbow` assets existing already.

I used the 'localhost' domain and didn't have problems after that. I haven't fired off TLS backed GRPC calls to the server yet but I wanted to share this in case it was needed by others.

```
brew info certstrap
certstrap: stable 1.2.0 (bottled)
```