### PR TITLE
Add Search.commitAll helper function for FDB mechanics test coverage

### DIFF
--- a/src/main/java/com/cloudant/search3/Search.java
+++ b/src/main/java/com/cloudant/search3/Search.java
@@ -287,6 +287,19 @@ public final class Search extends SearchGrpc.SearchImplBase implements Closeable
         handlers.clear();
     }
 
+    void commitAllHandlers() throws IOException {
+        // This package-private method is intended for index commit test coverage.
+        // It provides an easy interface for triggering commits to storage.
+        for (SearchHandler h : handlers.values()) {
+            try {
+                h.commit();
+            } catch (final IOException e) {
+                LOGGER.catching(e);
+                throw e;
+            }
+        }
+    }
+
     private <T> void execute(
             final Index index,
             final StreamObserver<T> responseObserver,

--- a/src/test/java/com/cloudant/search3/SearchTest.java
+++ b/src/test/java/com/cloudant/search3/SearchTest.java
@@ -107,6 +107,7 @@ public class SearchTest extends BaseFDBTest {
 
             // Index something.
             index(search, update(index, "foobar", "foo", "bar baz", true, false));
+            search.commitAllHandlers();
 
             // Find it with a search?
             final SearchRequest searchRequest = SearchRequest.newBuilder().setIndex(index).setQuery("foo:bar")
@@ -127,6 +128,7 @@ public class SearchTest extends BaseFDBTest {
             // Index something.
             index(search, update(index, "doc1", "foo", "bar", false, true));
             index(search, update(index, "doc2", "foo", "bar", false, true));
+            search.commitAllHandlers();
 
             // Find it with a search?
             final SearchRequest searchRequest = SearchRequest.newBuilder().setIndex(index).setQuery("_id:d*")
@@ -148,6 +150,7 @@ public class SearchTest extends BaseFDBTest {
             // Index something.
             index(search, update(index, "doc1", "foo", 1.0, false, true));
             index(search, update(index, "doc2", "foo", 2.0, false, true));
+            search.commitAllHandlers();
 
             final Ranges ranges = Ranges.newBuilder().putRanges("all", "[1 TO 2]").build();
 
@@ -171,6 +174,7 @@ public class SearchTest extends BaseFDBTest {
             // Index something.
             index(search, update(index, "doc1", "foo", "bar", false, true));
             index(search, update(index, "doc2", "foo", "baz", false, true));
+            search.commitAllHandlers();
 
             final Path path = Path.newBuilder().addParts("foo").addParts("baz").build();
 
@@ -194,6 +198,7 @@ public class SearchTest extends BaseFDBTest {
             index(search, update(index, "foo", field("lon", 0.5, true, false), field("lat", 57.15, true, false)));
             index(search, update(index, "bar", field("lon", 10.0, true, false), field("lat", 57.15, true, false)));
             index(search, update(index, "zzz", field("lon", 3.0, true, false), field("lat", 57.15, true, false)));
+            search.commitAllHandlers();
 
             {
                 final Sort sort = Sort.newBuilder().addFields("<distance,lon,lat,0.2,57.15,km>").build();
@@ -228,6 +233,7 @@ public class SearchTest extends BaseFDBTest {
 
             // Index something.
             index(search, update(index, "foobar", "foo", "bar baz", true, false));
+            search.commitAllHandlers();
 
             // Find it with a search?
             final Sort sort = Sort.newBuilder().addFields("foobar").build();
@@ -249,6 +255,7 @@ public class SearchTest extends BaseFDBTest {
             {
                 // Index something.
                 index(search, update(index, "foobar", "category", "foobar", false, false));
+                search.commitAllHandlers();
 
                 // Find it with a search?
                 final GroupSearchRequest groupSearchRequest = GroupSearchRequest.newBuilder().setIndex(index)
@@ -278,6 +285,7 @@ public class SearchTest extends BaseFDBTest {
 
             // Index something.
             index(search, update(index, "foobar", "foo", "bar baz", true, false));
+            search.commitAllHandlers();
 
             // Find it with a search?
             final SearchRequest searchRequest = SearchRequest.newBuilder().setIndex(index).setQuery("foo:bar")


### PR DESCRIPTION
# Summary

I noticed that our tests which interact with FDB were not actually experiencing Lucene index commits because we'd never reach the buffer limit or commit wait time period.

I don't think we should game the tests with sleeps to reach to commit time or mess with the limit (necessarily) -- here I add a convenience package-private method to the Search class which iterates over all handlers and commits them.

We already require FDB is running for `SearchTest`, this ensures the storage persistence behaviors of the stack are exercised during tests.

# Questions

Do we want a test case which performs operations against a specifically not-persisted indexed data set?