### PR TITLE
add SortedDocValuesField to TextField

### DIFF
--- a/src/main/java/com/cloudant/search3/DocumentBuilder.java
+++ b/src/main/java/com/cloudant/search3/DocumentBuilder.java
@@ -49,6 +49,7 @@ public final class DocumentBuilder {
 
     public DocumentBuilder addText(final String name, final String value, final boolean store, final boolean facet) {
         doc().add(new TextField(name, value, toStore(store)));
+        doc().add(new SortedDocValuesField(name, new BytesRef(value)));
         if (facet) {
             doc().add(new SortedSetDocValuesFacetField(name, value));
         }

--- a/src/test/java/com/cloudant/search3/DocumentBuilderTest.java
+++ b/src/test/java/com/cloudant/search3/DocumentBuilderTest.java
@@ -36,4 +36,12 @@ public class DocumentBuilderTest {
         final Document doc = builder.build();
         assertEquals(3, doc.getFields().size());
     }
+
+    @Test
+    public void addText() throws Exception {
+        final DocumentBuilder builder = new DocumentBuilder();
+        builder.addText("foo", "bar", false, false);
+        final Document doc = builder.build();
+        assertEquals(2, doc.getFields().size());
+    }
 }


### PR DESCRIPTION
When we switch to analyze true by default:
https://github.com/cloudant-labs/search3-erl/pull/15
string fields get indexed as textfields. For sort by string to work,
we need to add SortedDocValuesField along with the TextField.