### PR TITLE
Decouple dirty-index-commit and idle-search periodic checks against Search instances

### DIFF
--- a/src/test/resources/search3.ini
+++ b/src/test/resources/search3.ini
@@ -27,5 +27,9 @@ max_indexes_open = 1000
 # A dirty index (one with uncommitted writes or
 # pending update sequence) will be committed after
 # this interval.
-commit_interval_secs = 5
+commit_dirty_interval_secs = 30
+
+# Seconds before an idle Search instance triggers
+# a RuntimeException.
+idle_search_exit_secs = 60
  


### PR DESCRIPTION
In this PR I decouple the dirty Lucene index commit and idle Search instance checks. I also break out a fixed warm up delay of 10 seconds (up for debate).

After reading [some thoughts](https://solr.pl/en/2011/06/27/when-to-commit/) on when to commit Lucene indexes I varied the commit frequency and found 30s was the performer for raw indexing.

I figured we could set the idle index timeout to double the dirty index commit frequency to give at least one chance for an index to commit.

Reasoning:
  - The warm up delay should be different than the other check intervals
  - The two checks do different things and should have independently configurable delays
  - We want to avoid a dirty-commit/idle-exit race (throwing an exception due to idleness while the index is dirty)

Other changes to be aware of:
  - I moved `idle = false` to _before_ Lucene operations so we don't idle-exit mid-operation

TODO: I'm opening this for review but trying to gather some insightful data to power to commit interval choice. I went to collect a round of data (against a large Cloudant FDB cluster and colocated load generation node running search3-java) before PR late last night and found I was getting inconsistent indexing behavior. I'll have to sort out what was going on in the fog of late last night before I really push for a merge.

